### PR TITLE
Shell component: silent character stored in the history items

### DIFF
--- a/Drivers/sw/Shell.drv
+++ b/Drivers/sw/Shell.drv
@@ -762,8 +762,14 @@ bool %'ModuleName'%.%ReadLine(uint8_t *bufStart, uint8_t *buf, size_t bufSize, %
            *buf = '\0';
            bufSize++;
         }
-      } else if (isalnum(c) || (c==' ') ||
+      } else 
+%if %SilentModePrefixChar<>''
+      if (isalnum(c) || (c==' ') ||
+        (c=='\r') || (c=='\n') || (c=='%SilentModePrefixChar')) {
+%else
+      if (isalnum(c) || (c==' ') ||
         (c=='\r') || (c=='\n')) {
+%endif
 #if %'ModuleName'%.ECHO_ENABLED
         io->stdOut(c);                                           %>40/* echo character */
 #endif


### PR DESCRIPTION
If the "silent" character is not alpha-numeric (that is the typical scenario) it is discarded by the ReadLine function.
This is probably not what is expected.

Francesco