### PR TITLE
Fix FSL_USB_CDC_Device App_Task iterator bug

### DIFF
--- a/Drivers/sw/FSL_USB_CDC_Device.drv
+++ b/Drivers/sw/FSL_USB_CDC_Device.drv
@@ -758,7 +758,8 @@ uint8_t %'ModuleName'%.SendDataBlock(uint8_t *data, uint16_t dataSize)
 %include Common\FSL_USB_CDC_DeviceApp_Task.Inc
 uint8_t %'ModuleName'%.%App_Task(uint8_t *txBuf, size_t txBufSize)
 {
-  uint8_t i, res;
+  size_t i;
+  uint8_t res;
 
   /* device is %CPUDevice */
   /*lint -save -e522 function lacks side-effects */


### PR DESCRIPTION
If txBuf is larger than 255 bytes, App_Task wasn't working because the iterator doesn't match the txBufSize data type.