### PR TITLE
Correct FreeRTOS shell name error

### DIFF
--- a/Drivers/sw/FreeRTOS.drv
+++ b/Drivers/sw/FreeRTOS.drv
@@ -1999,10 +1999,10 @@ static uint8_t PrintTaskList(const %@Shell@'ModuleName'%.StdIOType *io) {
 
   res = ERR_OK;
 #if !configUSE_TRACE_FACILITY
-  CLS1_SendStr((uint8_t*)"Info: Enable configUSE_TRACE_FACILITY for additional task information.\r\n", io->stdOut);
+  %@Shell@'ModuleName'%.SendStr((uint8_t*)"Info: Enable configUSE_TRACE_FACILITY for additional task information.\r\n", io->stdOut);
 #endif
 #if !configGENERATE_RUN_TIME_STATS
-  CLS1_SendStr((uint8_t*)"Info: Enable configGENERATE_RUN_TIME_STATS for runtime statistics.\r\n", io->stdOut);
+  %@Shell@'ModuleName'%.SendStr((uint8_t*)"Info: Enable configGENERATE_RUN_TIME_STATS for runtime statistics.\r\n", io->stdOut);
 #endif
   /* header */
 #if configUSE_TRACE_FACILITY


### PR DESCRIPTION
Correct some errors when the shell has another name than CLS1 and the user don't activates "Use Trace Facility" and "Generate Run Time Stats"